### PR TITLE
修复了PHP8以上生成缩略图时int隐式转换精度丢失导致的报错问题

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -343,12 +343,12 @@ class Image
                     $scale = min($width / $w, $height / $h);
                 }
                 //设置缩略图的坐标及宽度和高度
-                $neww = $w * $scale;
-                $newh = $h * $scale;
+                $neww = intval($w * $scale);
+                $newh = intval($h * $scale);
                 $x    = $this->info['width'] - $w;
                 $y    = $this->info['height'] - $h;
-                $posx = ($width - $w * $scale) / 2;
-                $posy = ($height - $h * $scale) / 2;
+                $posx = intval(($width - $w * $scale) / 2);
+                $posy = intval(($height - $h * $scale) / 2);
                 do {
                     //创建新图像
                     $img = imagecreatetruecolor($width, $height);


### PR DESCRIPTION
PHP8.0以上会因为无法隐性转换带小数点的数字到int的问题, 导致生成缩略图是报错. 改为显式转换即可修复.
希望大佬尽早合并, 更新composer版本

Implicit conversion from float 28.083582089552237 to int loses precision
#0 [internal function]: think\initializer\Error->appError(8192, 'Implicit conver...', '...', 359)
#1 \vendor\topthink\think-image\src\Image.php(359): imagecopyresampled(Object(GdImage), Object(GdImage), 0.0, 28.083582089552, 0, 0, 128.0, 71.832835820896, 670, 376)
#2 \app\service\FileUpload.php(91): think\Image->thumb(128, 128, 2)